### PR TITLE
naive process verification, this solves the task dead lock

### DIFF
--- a/driver/handle.go
+++ b/driver/handle.go
@@ -89,15 +89,24 @@ func (h *taskHandle) run() {
 	h.stateLock.Unlock()
 	for {
 		time.Sleep(containerMonitorIntv)
+		pid, err := strconv.Atoi(h.Info.Pid)
+		if err == nil {
+			process, err := os.FindProcess(int(pid))
+			if err != nil {
+				break
+			}
+
+			if process.Signal(syscall.Signal(0)) != nil {
+				break
+			}
+		}
 	}
 	h.stateLock.Lock()
-	defer h.stateLock.Unlock()
-
 	h.State = drivers.TaskStateExited
 	h.exitResult.ExitCode = 0
 	h.exitResult.Signal = 0
 	h.completedAt = time.Now()
-
+	h.stateLock.Unlock()
 }
 
 /*


### PR DESCRIPTION
Thanks a lot for your project. It's helping me a lot with testing firecracker workload for me my needs :).
This is not yet as good and calling the api from your TODO, but it's the simplest way I found to have a clean exit.

If you create a job and update after a plan, the driver gets locked on the loop forever and don't release task on nomad even tho the job is dead.