### PR TITLE
naive process verification, this solves the task dead lock

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -298,6 +298,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		State:           drivers.TaskStateRunning,
 		startedAt:       time.Now().Round(time.Millisecond),
 		MachineInstance: m.Machine,
+		Info:            m.Info,
 		logger:          d.logger,
 	}
 


### PR DESCRIPTION
Thanks a lot for your project. It's helping me a lot with testing firecracker workload for me my needs :).
This is not yet as good and calling the api from your TODO, but it's the simplest way I found to have a clean exit.

If you create a job and update after a plan, the driver gets locked on the loop forever and don't release task on nomad even tho the job is dead.

@cneira now I found it for real :). It took some time to find that Info was missing from the struct. 

Thanks!

fix #7