### PR TITLE
Redirect tty log to nomad log output

### DIFF
--- a/driver/handle.go
+++ b/driver/handle.go
@@ -18,8 +18,6 @@
  * along with Firecracker-task-driver. If not, see <http://www.gnu.org/licenses/>.
  */
 
-
-
 package firevm
 
 import (
@@ -63,9 +61,9 @@ func (h *taskHandle) TaskStatus() *drivers.TaskStatus {
 		CompletedAt: h.completedAt,
 		ExitResult:  h.exitResult,
 		DriverAttributes: map[string]string{
-			"Ip":     h.Info.Ip,
-			"Serial": h.Info.Serial,
-			"Pid":    h.Info.Pid,
+			"Ip":         h.Info.Ip,
+			"SocketPath": h.Info.SocketPath,
+			"Pid":        h.Info.Pid,
 		},
 	}
 }


### PR DESCRIPTION
Pick up the pts information generated by firecracker and send to nomad logs.
I've changed the stdin to nil, to avoid errors everytime we read.

With that we are able to see the console output from firecracker on nomad logs. 